### PR TITLE
Do not define the same sg rule twice if the instance ssl port is the same as the instance port

### DIFF
--- a/elb_with_ssl_no_s3logs/sg.tf
+++ b/elb_with_ssl_no_s3logs/sg.tf
@@ -33,7 +33,7 @@ resource "aws_security_group_rule" "allow_elb_outgoing_to_backend" {
 }
 
 resource "aws_security_group_rule" "allow_elb_outgoing_secure_to_backend" {
-  count = "${var.backend_sg_count}"
+  count = "${var.instance_ssl_port == var.instance_port ? 0 : var.backend_sg_count}"
   security_group_id = "${aws_security_group.elb.id}"
   type = "egress"
   from_port       = "${var.instance_ssl_port}"

--- a/elb_with_ssl_with_s3logs/sg.tf
+++ b/elb_with_ssl_with_s3logs/sg.tf
@@ -33,11 +33,11 @@ resource "aws_security_group_rule" "allow_elb_outgoing_to_backend" {
 }
 
 resource "aws_security_group_rule" "allow_elb_outgoing_secure_to_backend" {
-  count = "${var.backend_sg_count}"
+  count = "${var.instance_ssl_port == var.instance_port ? 0 : var.backend_sg_count}"
   security_group_id = "${aws_security_group.elb.id}"
   type = "egress"
-  from_port       = "${var.lb_ssl_port}"
-  to_port         = "${var.lb_ssl_port}"
+  from_port       = "${var.instance_ssl_port}"
+  to_port         = "${var.instance_ssl_port}"
   protocol        = "tcp"
   source_security_group_id = "${var.backend_sg[count.index]}"
 }


### PR DESCRIPTION
When your instance_port is the same as the instance_ssl_port, you try to define twice the same sg rule. To correct this I added a conditional to check this. I followed the TF documentation to do this (https://www.terraform.io/docs/configuration/interpolation.html). 

I also fixed another little bug where the sg outgoing was using the lb_ssl_port instead of the instance_ssl_port.