### PR TITLE
Don't use a super long name when we have tags

### DIFF
--- a/alb/main.tf
+++ b/alb/main.tf
@@ -16,7 +16,7 @@ resource "aws_alb" "alb" {
 
 resource "aws_alb_target_group" "default" {
   count                = "${var.default_target_group_arn == "" ? 1 : 0}"
-  name                 = "${var.project}-${var.environment}-${var.name}-default"
+  name                 = "${var.name}-default-target"
   port                 = "${var.target_port}"
   protocol             = "${var.target_protocol}"
   vpc_id               = "${var.vpc_id}"


### PR DESCRIPTION
The maximum limit of the name is 32 characters.
We don't need all that info in the name when we already have it in the tags.

Possibly breaking?