### PR TITLE
Allow the healthcheck to use a different protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ Create an ALB listener\_rule and attached target\_group
 * [`target_health_healthy_threshold`]: Int(optional, 5): The number of consecutive health checks successes before considering a target healthy
 * [`target_health_unhealthy_threshold`]: Int(optional, 2): The number of consecutive health check failures before considering a target unhealthy
 * [`target_health_matcher`]: Int(optional, 200): The HTTP codes to use when checking for a successful response from a target
+* [`target_health_protocol`]: String(optional, HTTP): The protocol to use for the healthcheck
 * [`tags`]: Map(optional, {}): Optional tags
 
 ### Output

--- a/alb/main.tf
+++ b/alb/main.tf
@@ -30,6 +30,7 @@ resource "aws_alb_target_group" "default" {
     healthy_threshold   = "${var.target_health_healthy_threshold}"
     unhealthy_threshold = "${var.target_health_unhealthy_threshold}"
     matcher             = "${var.target_health_matcher}"
+    protocol            = "${var.target_health_protocol}"
   }
 
   tags = "${merge("${var.tags}",

--- a/alb/variables.tf
+++ b/alb/variables.tf
@@ -132,3 +132,8 @@ variable "source_subnet_cidrs" {
   type        = "list"
   default     = ["0.0.0.0/0"]
 }
+
+variable "target_health_protocol" {
+  default     = "HTTP"
+  description = "Protocol to use for the healthcheck"
+}


### PR DESCRIPTION
Instead of only using the defualt HTTP protocol, also allow setting
HTTPS