### PR TITLE
Add target_security_groups_count param

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Setup an ALB with related resources.
 * [`target_health_unhealthy_threshold`]: Int(optional, 2): The number of consecutive health check failures before considering a target unhealthy
 * [`target_health_matcher`]: Int(optional, 200): The HTTP codes to use when checking for a successful response from a target
 * [`target_security_groups`]: List(required): Security groups of the ALB target instances
+* [`target_security_groups_count`]: Int(required): Number of security groups of the ALB target instances
 * [`source_subnet_cidrs`]: List(optional, ["0.0.0.0/0"]): Subnet CIDR blocks from where the ALB will receive traffic
 
 ### Output

--- a/alb/sg.tf
+++ b/alb/sg.tf
@@ -31,7 +31,7 @@ resource "aws_security_group_rule" "sg_alb_https_ingress" {
 }
 
 resource "aws_security_group_rule" "sg_alb_target_egress" {
-  count                    = "${length(var.target_security_groups)}"
+  count                    = "${var.target_security_groups_count}"
   security_group_id        = "${aws_security_group.sg_alb.id}"
   type                     = "egress"
   from_port                = "${var.target_port}"

--- a/alb/variables.tf
+++ b/alb/variables.tf
@@ -130,7 +130,6 @@ variable "target_security_groups" {
 
 variable "target_security_groups_count" {
   description = "Int(required): Number of security groups of the ALB target instances"
-  default = 1
 }
 
 variable "source_subnet_cidrs" {

--- a/alb/variables.tf
+++ b/alb/variables.tf
@@ -127,6 +127,12 @@ variable "target_security_groups" {
   type        = "list"
 }
 
+
+variable "target_security_groups_count" {
+  description = "Int(required): Number of security groups of the ALB target instances"
+  default = 1
+}
+
 variable "source_subnet_cidrs" {
   description = "List(optional, [\"0.0.0.0/0\"]): Subnet CIDR blocks from where the ALB will receive traffic"
   type        = "list"


### PR DESCRIPTION
count can never be a computed param. getting the count from a list
of security_groups usually leads to errors.

If you still want an automatic count, pass the count as
target_security_groups_count = "${length(...)}"