### PR TITLE
Add target_health_protocol to ALB

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ module "alb" {
 * [`alb_arn`]: String(required): ARN of the ALB on which this listener will be attached.
 * [`alb_sg_id`]: String(required): ID of the security group attached to the load balancer
 * [`default_target_group_arn`]: String(optional, ""): Default target group ARN to add to the HTTP listener. If this value is set please set `create_default_target_group` to false
-* [`create_default_target_group`]: String(optional, true): Whether to creates or not a default target group if not set 
+* [`create_default_target_group`]: String(optional, true): Whether to creates or not a default target group if not set
 * [`ingress_port`]: Int(optional, -1): Ingress port the ALB is listening to
 * [`https_certificate_arn`]: String(optional, ""): IAM ARN of the SSL certificate for the HTTPS listener
 * [`target_port`]: Int(optional, 80): The port of which targets receive traffic
@@ -75,6 +75,7 @@ module "alb" {
 * [`target_health_healthy_threshold`]: Int(optional, 5): The number of consecutive health checks successes before considering a target healthy
 * [`target_health_unhealthy_threshold`]: Int(optional, 2): The number of consecutive health check failures before considering a target unhealthy
 * [`target_health_matcher`]: Int(optional, 200): The HTTP codes to use when checking for a successful response from a target
+* [`target_health_protocol`]: String(optional): The protocol to use for the health check. If not set, it will use the same protocal as target_protocol
 * [`source_subnet_cidrs`]: List(optional, ["0.0.0.0/0"]): Subnet CIDR blocks from where the ALB will receive traffic
 * [`tags`]: Map(optional, {}): Optional tags
 
@@ -138,7 +139,7 @@ and the corresponding PR is https://github.com/terraform-providers/terraform-pro
 * [`target_health_healthy_threshold`]: Int(optional, 5): The number of consecutive health checks successes before considering a target healthy
 * [`target_health_unhealthy_threshold`]: Int(optional, 2): The number of consecutive health check failures before considering a target unhealthy
 * [`target_health_matcher`]: Int(optional, 200): The HTTP codes to use when checking for a successful response from a target
-* [`target_health_protocol`]: String(optional, HTTP): The protocol to use for the healthcheck
+* [`target_health_protocol`]: String(optional): The protocol to use for the health check. If not set, it will use the same protocal as target_protocol
 * [`tags`]: Map(optional, {}): Optional tags
 
 ### Output

--- a/alb_listener/main.tf
+++ b/alb_listener/main.tf
@@ -18,7 +18,7 @@ resource "aws_lb_target_group" "default" {
     healthy_threshold   = "${var.target_health_healthy_threshold}"
     unhealthy_threshold = "${var.target_health_unhealthy_threshold}"
     matcher             = "${var.target_health_matcher}"
-    protocol            = "${var.target_health_protocol}"
+    protocol            = "${var.target_health_protocol == "" ? var.target_protocol : var.target_health_protocol}"
   }
 
   tags = "${merge("${var.tags}",

--- a/alb_listener/variables.tf
+++ b/alb_listener/variables.tf
@@ -100,8 +100,8 @@ variable "source_subnet_cidrs" {
 }
 
 variable "target_health_protocol" {
-  default     = "HTTP"
-  description = "Protocol to use for the healthcheck"
+  description = "String(optional): The protocol to use for the health check. If not set, it will use the same protocal as target_protocol"
+  default     = ""
 }
 
 variable "tags" {

--- a/alb_rule_target/main.tf
+++ b/alb_rule_target/main.tf
@@ -28,6 +28,7 @@ resource "aws_alb_target_group" "target" {
     healthy_threshold   = "${var.target_health_healthy_threshold}"
     unhealthy_threshold = "${var.target_health_unhealthy_threshold}"
     matcher             = "${var.target_health_matcher}"
+    protocol            = "${var.target_health_protocol == "" ? var.target_protocol : var.target_health_protocol}"
   }
 
   tags = "${merge("${var.tags}",

--- a/alb_rule_target/variables.tf
+++ b/alb_rule_target/variables.tf
@@ -83,6 +83,11 @@ variable "target_health_matcher" {
   default     = 200
 }
 
+variable "target_health_protocol" {
+  description = "String(optional): The protocol to use for the health check. If not set, it will use the same protocal as target_protocol"
+  default     = ""
+}
+
 variable "tags" {
   description = "Map(optional, {}): Optional tags"
   type        = "map"


### PR DESCRIPTION
Sometimes we want to change the protocol of target_health_protocol to something else than HTTP (eg HTTPS). This change makes it possible. In 99% of the cases the target_health_protocol will be the same as the target_protocol. If this is the case, by working with a condition you only need to set the target_protocol. You can still override it when you need it.