### PR TITLE
Allow to specify target_type in alb_rule_target module

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ and the corresponding PR is https://github.com/terraform-providers/terraform-pro
 * [`target_health_unhealthy_threshold`]: Int(optional, 2): The number of consecutive health check failures before considering a target unhealthy
 * [`target_health_matcher`]: Int(optional, 200): The HTTP codes to use when checking for a successful response from a target
 * [`target_health_protocol`]: String(optional): The protocol to use for the health check. If not set, it will use the same protocal as target_protocol
+* [`target_type`]: String(optional, "instance"): The type of target that you must specify when registering targets with this target group. The possible values are instance (targets are specified by instance ID) or ip (targets are specified by IP address).
 * [`tags`]: Map(optional, {}): Optional tags
 
 ### Output

--- a/alb_rule_target/main.tf
+++ b/alb_rule_target/main.tf
@@ -20,6 +20,7 @@ resource "aws_alb_target_group" "target" {
   vpc_id               = "${var.vpc_id}"
   deregistration_delay = "${var.target_deregistration_delay}"
   stickiness           = ["${var.target_stickiness}"]
+  target_type          = "${var.target_type}"
 
   health_check {
     interval            = "${var.target_health_interval}"

--- a/alb_rule_target/variables.tf
+++ b/alb_rule_target/variables.tf
@@ -93,3 +93,8 @@ variable "tags" {
   type        = "map"
   default     = {}
 }
+
+variable "target_type" {
+  description = "The type of target that you must specify when registering targets with this target group. The possible values are instance (targets are specified by instance ID) or ip (targets are specified by IP address). The default is instance"
+  default     = "instance"
+}


### PR DESCRIPTION
This is useful when using task networking on ECS, as it requires the alb rule target to be type `ip`.