### PR TITLE
Shorten the names of the ELBs

### DIFF
--- a/elb_no_ssl_no_s3logs/main.tf
+++ b/elb_no_ssl_no_s3logs/main.tf
@@ -1,5 +1,5 @@
 resource "aws_elb" "elb" {
-  name                        = "${var.project}-${var.environment}-${var.name}-elb"
+  name                        = "${var.project}-${var.environment}-${var.name}"
   subnets                     = ["${var.subnets}"]
   internal                    = "${var.internal}"
   cross_zone_load_balancing   = true
@@ -24,7 +24,7 @@ resource "aws_elb" "elb" {
   }
 
   tags {
-    Name        = "${var.project}-${var.environment}-${var.name}-elb"
+    Name        = "${var.project}-${var.environment}-${var.name}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/elb_no_ssl_with_s3logs/main.tf
+++ b/elb_no_ssl_with_s3logs/main.tf
@@ -1,5 +1,5 @@
 resource "aws_elb" "elb" {
-  name                        = "${var.project}-${var.environment}-${var.name}-elb"
+  name                        = "${var.project}-${var.environment}-${var.name}"
   subnets                     = ["${var.subnets}"]
   internal                    = "${var.internal}"
   cross_zone_load_balancing   = true
@@ -31,7 +31,7 @@ resource "aws_elb" "elb" {
   }
 
   tags {
-    Name        = "${var.project}-${var.environment}-${var.name}-elb"
+    Name        = "${var.project}-${var.environment}-${var.name}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/elb_only_ssl_no_s3logs/main.tf
+++ b/elb_only_ssl_no_s3logs/main.tf
@@ -1,5 +1,5 @@
 resource "aws_elb" "elb" {
-  name                        = "${var.project}-${var.environment}-${var.name}-elb"
+  name                        = "${var.project}-${var.environment}-${var.name}"
   subnets                     = ["${var.subnets}"]
   internal                    = "${var.internal}"
   cross_zone_load_balancing   = true
@@ -25,7 +25,7 @@ resource "aws_elb" "elb" {
   }
 
   tags {
-    Name        = "${var.project}-${var.environment}-${var.name}-elb"
+    Name        = "${var.project}-${var.environment}-${var.name}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/elb_only_ssl_with_s3logs/main.tf
+++ b/elb_only_ssl_with_s3logs/main.tf
@@ -1,5 +1,5 @@
 resource "aws_elb" "elb" {
-  name                        = "${var.project}-${var.environment}-${var.name}-elb"
+  name                        = "${var.project}-${var.environment}-${var.name}"
   subnets                     = ["${var.subnets}"]
   internal                    = "${var.internal}"
   cross_zone_load_balancing   = true
@@ -32,7 +32,7 @@ resource "aws_elb" "elb" {
   }
 
   tags {
-    Name        = "${var.project}-${var.environment}-${var.name}-elb"
+    Name        = "${var.project}-${var.environment}-${var.name}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/elb_with_ssl_no_s3logs/main.tf
+++ b/elb_with_ssl_no_s3logs/main.tf
@@ -1,5 +1,5 @@
 resource "aws_elb" "elb" {
-  name                        = "${var.project}-${var.environment}-${var.name}-elb"
+  name                        = "${var.project}-${var.environment}-${var.name}"
   subnets                     = ["${var.subnets}"]
   internal                    = "${var.internal}"
   cross_zone_load_balancing   = true
@@ -32,7 +32,7 @@ resource "aws_elb" "elb" {
   }
 
   tags {
-    Name        = "${var.project}-${var.environment}-${var.name}-elb"
+    Name        = "${var.project}-${var.environment}-${var.name}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }

--- a/elb_with_ssl_with_s3logs/main.tf
+++ b/elb_with_ssl_with_s3logs/main.tf
@@ -1,5 +1,5 @@
 resource "aws_elb" "elb" {
-  name                        = "${var.project}-${var.environment}-${var.name}-elb"
+  name                        = "${var.project}-${var.environment}-${var.name}"
   subnets                     = ["${var.subnets}"]
   internal                    = "${var.internal}"
   cross_zone_load_balancing   = true
@@ -39,7 +39,7 @@ resource "aws_elb" "elb" {
   }
 
   tags {
-    Name        = "${var.project}-${var.environment}-${var.name}-elb"
+    Name        = "${var.project}-${var.environment}-${var.name}"
     Environment = "${var.environment}"
     Project     = "${var.project}"
   }


### PR DESCRIPTION
We sometimes bump into the 32 character limit on the ELB names, this will give us 4 more characters of margin. Also it's kind of useless to have an "-elb" on the ELB names imo.