### PR TITLE
Adding option to add more ELB listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ module "elb" {
  * [`unhealthy_threshold`]: Integer(optional):default 2. The number of checks before the instance is declared unhealthy.
  * [`health_timeout`]: Integer(optional):default 3. The length of time before the check times out.
  * [`health_interval`]: Integer(optional):default 30. The interval between checks.
-
+ * [`custom_listeners`]: List(optional): default []. A list of maps of listeners. Here a link to the [available valuses](https://www.terraform.io/docs/providers/aws/r/elb.html#instance_port)
 #### Output
 
  * [`elb_id`]: String: The id of the ELB

--- a/elb_with_ssl_no_s3logs/main.tf
+++ b/elb_with_ssl_no_s3logs/main.tf
@@ -26,7 +26,7 @@ resource "aws_elb" "elb" {
   connection_draining_timeout = "${var.connection_draining_timeout}"
   security_groups             = ["${aws_security_group.elb.id}"]
 
-  listener = "${concat(local.listener,var.more_listeners)}"
+  listener = "${concat(local.listener,var.custom_listeners)}"
 
   health_check {
     healthy_threshold   = "${var.healthy_threshold}"

--- a/elb_with_ssl_no_s3logs/main.tf
+++ b/elb_with_ssl_no_s3logs/main.tf
@@ -1,3 +1,21 @@
+locals {
+  listener = [
+    {
+      instance_port     = "${var.instance_port}"
+      instance_protocol = "${var.instance_protocol}"
+      lb_port           = "${var.lb_port}"
+      lb_protocol       = "${var.lb_protocol}"
+    },
+    {
+      instance_port      = "${var.instance_ssl_port}"
+      instance_protocol  = "${var.instance_ssl_protocol}"
+      lb_port            = "${var.lb_ssl_port}"
+      lb_protocol        = "${var.lb_ssl_protocol}"
+      ssl_certificate_id = "${var.ssl_certificate_id}"
+    },
+  ]
+}
+
 resource "aws_elb" "elb" {
   name                        = "${var.project}-${var.environment}-${var.name}"
   subnets                     = ["${var.subnets}"]
@@ -8,20 +26,7 @@ resource "aws_elb" "elb" {
   connection_draining_timeout = "${var.connection_draining_timeout}"
   security_groups             = ["${aws_security_group.elb.id}"]
 
-  listener {
-    instance_port     = "${var.instance_port}"
-    instance_protocol = "${var.instance_protocol}"
-    lb_port           = "${var.lb_port}"
-    lb_protocol       = "${var.lb_protocol}"
-  }
-
-  listener {
-    instance_port      = "${var.instance_ssl_port}"
-    instance_protocol  = "${var.instance_ssl_protocol}"
-    lb_port            = "${var.lb_ssl_port}"
-    lb_protocol        = "${var.lb_ssl_protocol}"
-    ssl_certificate_id = "${var.ssl_certificate_id}"
-  }
+  listener = "${concat(local.listener,var.more_listeners)}"
 
   health_check {
     healthy_threshold   = "${var.healthy_threshold}"

--- a/elb_with_ssl_no_s3logs/variables.tf
+++ b/elb_with_ssl_no_s3logs/variables.tf
@@ -110,7 +110,7 @@ variable "ingoing_allowed_ips" {
   type    = "list"
 }
 
-variable "more_listeners" {
+variable "custom_listeners" {
   type    = "list"
   default = []
 }

--- a/elb_with_ssl_no_s3logs/variables.tf
+++ b/elb_with_ssl_no_s3logs/variables.tf
@@ -109,3 +109,8 @@ variable "ingoing_allowed_ips" {
   default = ["0.0.0.0/0"]
   type    = "list"
 }
+
+variable "more_listeners" {
+  type    = "list"
+  default = []
+}


### PR DESCRIPTION
This PR adds the option to specify additional listeners to the classic ELB. This is a really useful solution for custom configuration and doesn't affect the current setup.
