### PR TITLE
restore functionality of elb custom listeners

### DIFF
--- a/elb/main.tf
+++ b/elb/main.tf
@@ -45,6 +45,17 @@ resource "aws_elb" "elb" {
     }
   }
 
+  dynamic "listener" {
+    for_each = var.custom_listeners
+    content {
+      instance_port      = lookup(listener.value, "instance_port", null)
+      instance_protocol  = lookup(listener.value, "instance_protocol", null )
+      lb_port            = lookup(listener.value, "lb_port", null )
+      lb_protocol        = lookup(listener.value, "lb_protocol", null )
+      ssl_certificate_id = lookup(listener.value, "ssl_certificate_id", null )
+    }
+  }
+
   health_check {
     healthy_threshold   = var.healthy_threshold
     unhealthy_threshold = var.unhealthy_threshold

--- a/elb/variables.tf
+++ b/elb/variables.tf
@@ -135,3 +135,8 @@ variable "ingoing_allowed_ips" {
   default = ["0.0.0.0/0"]
   type    = list(string)
 }
+
+variable "custom_listeners" {
+  default = []
+  type    = list(map(string))
+}


### PR DESCRIPTION
somehow this was lost while merging elbs modules from this [PR](https://github.com/skyscrapers/terraform-loadbalancers/pull/22), and it's needed for [concourse module](https://github.com/skyscrapers/terraform-concourse/blob/master/ecs-web/elb.tf#L22)

(also tested with a tf plan)