### PR TITLE
Enable TLS for nlb listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ part of your target group.
 * [`target_health_unhealthy_threshold`]: Int(optional, 2): The number of consecutive health check failures before considering a target unhealthy
 * [`target_type`]: String(optional, "instance"): The type of target that you must specify when registering targets with this target group. The possible values are instance (targets are specified by instance ID) or ip (targets are specified by IP address).
 * [`tags`]: Map(string)(optional, {}): Optional tags
+* [`listener_protocal`]: String(optional, "TCP"): The protocol for connections from clients to the load balancer. Valid values are TCP, TLS, UDP, or TCP_UDP
+* [`certificate_arn`]: String(optional, ""): The ARN of the default SSL server certificate. Required if protocol is TLS
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ module "alb" {
 * [`target_health_healthy_threshold`]: Int(optional, 5): The number of consecutive health checks successes before considering a target healthy
 * [`target_health_unhealthy_threshold`]: Int(optional, 2): The number of consecutive health check failures before considering a target unhealthy
 * [`target_health_matcher`]: Int(optional, 200): The HTTP codes to use when checking for a successful response from a target
-* [`target_health_protocol`]: String(optional): The protocol to use for the health check. If not set, it will use the same protocal as target_protocol
+* [`target_health_protocol`]: String(optional): The protocol to use for the health check. If not set, it will use the same protocol as target_protocol
 * [`source_subnet_cidrs`]: List(string)(optional, ["0.0.0.0/0"]): Subnet CIDR blocks from where the ALB will receive traffic
 * [`tags`]: Map(string)(optional, {}): Optional tags
 
@@ -237,7 +237,7 @@ part of your target group.
 * [`target_health_unhealthy_threshold`]: Int(optional, 2): The number of consecutive health check failures before considering a target unhealthy
 * [`target_type`]: String(optional, "instance"): The type of target that you must specify when registering targets with this target group. The possible values are instance (targets are specified by instance ID) or ip (targets are specified by IP address).
 * [`tags`]: Map(string)(optional, {}): Optional tags
-* [`listener_protocal`]: String(optional, "TCP"): The protocol for connections from clients to the load balancer. Valid values are TCP, TLS, UDP, or TCP_UDP
+* [`listener_protocol`]: String(optional, "TCP"): The protocol for connections from clients to the load balancer. Valid values are TCP, TLS, UDP, or TCP_UDP
 * [`certificate_arn`]: String(optional, ""): The ARN of the default SSL server certificate. Required if protocol is TLS
 
 ### Output

--- a/nlb_listener/main.tf
+++ b/nlb_listener/main.tf
@@ -31,7 +31,8 @@ resource "aws_lb_target_group" "default" {
 resource "aws_lb_listener" "listener" {
   load_balancer_arn = var.nlb_arn
   port              = var.ingress_port
-  protocol          = "TCP"
+  protocol          = var.listener_protocol
+  certificate_arn   = var.certificate_arn
 
   default_action {
     # Using join with resource.* as workaround for https://github.com/hashicorp/hil/issues/50

--- a/nlb_listener/variables.tf
+++ b/nlb_listener/variables.tf
@@ -67,6 +67,6 @@ variable "listener_protocol" {
 variable "certificate_arn" {
  description = "String(optional, \"\")  The ARN of the default SSL server certificate. Required if protocol is TLS"
  type        = string
- default     = ""
+ default     = null
 }
 

--- a/nlb_listener/variables.tf
+++ b/nlb_listener/variables.tf
@@ -58,3 +58,15 @@ variable "tags" {
   default     = {}
 }
 
+variable "listener_protocol" {
+ description = "String(optional, \"TCP\") The protocol for connections from clients to the load balancer. Valid values are TCP, TLS, UDP, or TCP_UDP"
+ type        = string
+ default     = "TCP"
+}
+
+variable "certificate_arn" {
+ description = "String(optional, \"\")  The ARN of the default SSL server certificate. Required if protocol is TLS"
+ type        = string
+ default     = ""
+}
+


### PR DESCRIPTION
Allow using TLS termination for NLB listener

Related issue: https://github.com/sweepbright/infrastructure/issues/520